### PR TITLE
Update Bevy to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ readme = "README.md"
 repository = "https://github.com/hankjordan/bevy_save"
 
 [dev-dependencies]
-bevy = { version = "0.13" }
-bevy-inspector-egui = "0.23"
+bevy = { version = "0.14" }
+bevy-inspector-egui = "0.25"
 ron = "0.8"
 
 [features]
@@ -23,7 +23,7 @@ bevy_sprite = ["bevy/bevy_sprite"]
 brotli = ["dep:brotli"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-bevy = { version = "0.13", default-features = false, features = ["webgl2"] }
+bevy = { version = "0.14", default-features = false, features = ["webgl2"] }
 web-sys = { version = "0.3", default-features = false, features = [
     "Storage",
     "Window",
@@ -32,7 +32,7 @@ wasm-bindgen = { version = "0.2", default-features = false }
 fragile = "2.0"
 
 [dependencies]
-bevy = { version = "0.13", default-features = false, features = ["bevy_scene"] }
+bevy = { version = "0.14", default-features = false, features = ["bevy_scene"] }
 rmp-serde = "1.1"
 serde_json = "1.0"
 serde = { version = "1.0" }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ With the default `FileIO` backend, your save directory is managed for you.
 
 On WASM, snapshots are saved to `LocalStorage`, with the key:
 
-```
+```ignore
 WORKSPACE.KEY
 ```
 

--- a/examples/breakout.rs
+++ b/examples/breakout.rs
@@ -2,21 +2,10 @@
 //! Modified to demonstrate integration of `bevy_save`.
 
 use bevy::{
-    ecs::system::{
-        SystemParam,
-        SystemState,
-    },
-    math::bounding::{
-        Aabb2d,
-        BoundingCircle,
-        BoundingVolume,
-        IntersectsVolume,
-    },
+    ecs::system::{SystemParam, SystemState},
+    math::bounding::{Aabb2d, BoundingCircle, BoundingVolume, IntersectsVolume},
     prelude::*,
-    sprite::{
-        MaterialMesh2dBundle,
-        Mesh2dHandle,
-    },
+    sprite::{MaterialMesh2dBundle, Mesh2dHandle},
     utils::Instant,
 };
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
@@ -61,16 +50,16 @@ const HELP_TEXT_PADDING: Val = Val::Px(5.0);
 
 const TOAST_FONT_SIZE: f32 = 32.0;
 const TOAST_TEXT_PADDING: Val = Val::Px(5.0);
-const TOAST_TEXT_COLOR: Color = Color::rgb(0.5, 0.1, 0.1);
+const TOAST_TEXT_COLOR: Color = Color::srgb(0.5, 0.1, 0.1);
 const TOAST_DURATION: f32 = 0.5;
 
-const BACKGROUND_COLOR: Color = Color::rgb(0.9, 0.9, 0.9);
-const PADDLE_COLOR: Color = Color::rgb(0.3, 0.3, 0.7);
-const BALL_COLOR: Color = Color::rgb(1.0, 0.5, 0.5);
-const BRICK_COLOR: Color = Color::rgb(0.5, 0.5, 1.0);
-const WALL_COLOR: Color = Color::rgb(0.8, 0.8, 0.8);
-const TEXT_COLOR: Color = Color::rgb(0.5, 0.5, 1.0);
-const SCORE_COLOR: Color = Color::rgb(1.0, 0.5, 0.5);
+const BACKGROUND_COLOR: Color = Color::srgb(0.9, 0.9, 0.9);
+const PADDLE_COLOR: Color = Color::srgb(0.3, 0.3, 0.7);
+const BALL_COLOR: Color = Color::srgb(1.0, 0.5, 0.5);
+const BRICK_COLOR: Color = Color::srgb(0.5, 0.5, 1.0);
+const WALL_COLOR: Color = Color::srgb(0.8, 0.8, 0.8);
+const TEXT_COLOR: Color = Color::srgb(0.5, 0.5, 1.0);
+const SCORE_COLOR: Color = Color::srgb(1.0, 0.5, 0.5);
 
 #[rustfmt::skip]
 fn main() {
@@ -95,7 +84,7 @@ fn main() {
                 // `chain`ing systems together runs them in order
                 .chain(),
         )
-        .add_systems(Update, (update_scoreboard, bevy::window::close_on_esc))
+        .add_systems(Update, (update_scoreboard, close_on_esc))
 
         .add_plugins((
             // Inspector
@@ -282,11 +271,14 @@ fn setup(
     // Scoreboard
     commands.spawn((
         TextBundle::from_sections([
-            TextSection::new("Score: ", TextStyle {
-                font_size: SCOREBOARD_FONT_SIZE,
-                color: TEXT_COLOR,
-                ..default()
-            }),
+            TextSection::new(
+                "Score: ",
+                TextStyle {
+                    font_size: SCOREBOARD_FONT_SIZE,
+                    color: TEXT_COLOR,
+                    ..default()
+                },
+            ),
             TextSection::from_style(TextStyle {
                 font_size: SCOREBOARD_FONT_SIZE,
                 color: SCORE_COLOR,
@@ -510,11 +502,14 @@ fn collide_with_side(ball: BoundingCircle, wall: Aabb2d) -> Option<Collision> {
 fn setup_help(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(
         TextBundle::from_sections([
-            TextSection::new("Enter - Save | Backspace - Load\n", TextStyle {
-                font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                font_size: HELP_FONT_SIZE,
-                color: TEXT_COLOR,
-            }),
+            TextSection::new(
+                "Enter - Save | Backspace - Load\n",
+                TextStyle {
+                    font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                    font_size: HELP_FONT_SIZE,
+                    color: TEXT_COLOR,
+                },
+            ),
             TextSection::new(
                 "Space - Checkpoint | A - Rollback | D - Rollforward\n",
                 TextStyle {
@@ -538,11 +533,14 @@ struct EntityCount;
 
 fn setup_entity_count(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
-        TextBundle::from_section("", TextStyle {
-            font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-            font_size: HELP_FONT_SIZE,
-            color: TEXT_COLOR,
-        })
+        TextBundle::from_section(
+            "",
+            TextStyle {
+                font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                font_size: HELP_FONT_SIZE,
+                color: TEXT_COLOR,
+            },
+        )
         .with_style(Style {
             position_type: PositionType::Absolute,
             top: HELP_TEXT_PADDING,
@@ -593,11 +591,14 @@ impl<'w, 's> Toaster<'w, 's> {
         }
 
         self.commands.spawn((
-            TextBundle::from_sections([TextSection::new(text, TextStyle {
-                font: self.asset_server.load("fonts/FiraMono-Medium.ttf"),
-                font_size: TOAST_FONT_SIZE,
-                color: TOAST_TEXT_COLOR,
-            })])
+            TextBundle::from_sections([TextSection::new(
+                text,
+                TextStyle {
+                    font: self.asset_server.load("fonts/FiraMono-Medium.ttf"),
+                    font_size: TOAST_FONT_SIZE,
+                    color: TOAST_TEXT_COLOR,
+                },
+            )])
             .with_style(Style {
                 position_type: PositionType::Absolute,
                 bottom: TOAST_TEXT_PADDING,
@@ -685,5 +686,21 @@ fn handle_save_input(world: &mut World) {
         toaster.show(text);
 
         state.apply(world);
+    }
+}
+
+pub fn close_on_esc(
+    mut commands: Commands,
+    focused_windows: Query<(Entity, &Window)>,
+    input: Res<ButtonInput<KeyCode>>,
+) {
+    for (window, focus) in focused_windows.iter() {
+        if !focus.focused {
+            continue;
+        }
+
+        if input.just_pressed(KeyCode::Escape) {
+            commands.entity(window).despawn();
+        }
     }
 }

--- a/examples/pipeline.rs
+++ b/examples/pipeline.rs
@@ -1,8 +1,6 @@
 //! An example of how to implement your own `Pipeline`.
 
-use bevy::{
-    ecs::entity::EntityHashMap, prelude::*, utils::HashMap
-};
+use bevy::{ecs::entity::EntityHashMap, prelude::*, utils::HashMap};
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_save::prelude::*;
 
@@ -43,14 +41,17 @@ fn setup_world(mut commands: Commands) {
             })
             .map(|(x, y, t)| (TilePosition { x, y }, t))
             .map(|(p, t)| {
-                (p, match t {
-                    'x' => Tile::Empty,
-                    'g' => Tile::Grass,
-                    'd' => Tile::Dirt,
-                    's' => Tile::Stone,
-                    'i' => Tile::IronOre,
-                    _ => panic!(),
-                })
+                (
+                    p,
+                    match t {
+                        'x' => Tile::Empty,
+                        'g' => Tile::Grass,
+                        'd' => Tile::Dirt,
+                        's' => Tile::Stone,
+                        'i' => Tile::IronOre,
+                        _ => panic!(),
+                    },
+                )
             })
             .map(|(p, t)| (p, commands.spawn(t).id()))
             .collect(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -23,13 +23,13 @@ impl AppSaveableExt for App {
     }
 
     fn allow_rollback<T: Any>(&mut self) -> &mut Self {
-        let mut registry = self.world.resource_mut::<RollbackRegistry>();
+        let mut registry = self.world_mut().resource_mut::<RollbackRegistry>();
         registry.allow::<T>();
         self
     }
 
     fn deny_rollback<T: Any>(&mut self) -> &mut Self {
-        let mut registry = self.world.resource_mut::<RollbackRegistry>();
+        let mut registry = self.world_mut().resource_mut::<RollbackRegistry>();
         registry.deny::<T>();
         self
     }

--- a/src/applier.rs
+++ b/src/applier.rs
@@ -25,7 +25,7 @@ use crate::{Error, Snapshot};
 /// # let mut app = App::new();
 /// # app.add_plugins(MinimalPlugins);
 /// # app.add_plugins(SavePlugins);
-/// # let world = &mut app.world;
+/// # let world = app.world_mut();
 /// # let snapshot = Snapshot::from_world(world);
 /// # let parent = world.spawn_empty().id();
 /// snapshot

--- a/src/applier.rs
+++ b/src/applier.rs
@@ -1,28 +1,19 @@
-use std::{
-    any::TypeId,
-    marker::PhantomData,
-};
+use std::{any::TypeId, marker::PhantomData};
 
 use bevy::{
     ecs::{
         entity::EntityHashMap,
         query::QueryFilter,
         reflect::ReflectMapEntities,
-        system::{
-            CommandQueue,
-            EntityCommands,
-        },
-        world::EntityRef,
+        system::EntityCommands,
+        world::{CommandQueue, EntityRef},
     },
     prelude::*,
     scene::SceneSpawnError,
     utils::HashMap,
 };
 
-use crate::{
-    Error,
-    Snapshot,
-};
+use crate::{Error, Snapshot};
 
 /// A [`Hook`] runs on each entity when applying a snapshot.
 ///
@@ -151,7 +142,7 @@ impl<'a, F: QueryFilter> SnapshotApplier<'a, F> {
 
             // If the world already contains an instance of the given resource
             // just apply the (possibly) new value, otherwise insert the resource
-            reflect_resource.apply_or_insert(self.world, &**resource);
+            reflect_resource.apply_or_insert(self.world, &**resource, &type_registry);
         }
 
         // Despawn entities

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,20 +1,8 @@
-use std::{
-    any::Any,
-    collections::BTreeMap,
-};
+use std::{any::Any, collections::BTreeMap};
 
-use bevy::{
-    ecs::component::ComponentId,
-    prelude::*,
-    scene::DynamicEntity,
-};
+use bevy::{ecs::component::ComponentId, prelude::*, scene::DynamicEntity};
 
-use crate::{
-    CloneReflect,
-    RollbackRegistry,
-    Rollbacks,
-    Snapshot,
-};
+use crate::{CloneReflect, RollbackRegistry, Rollbacks, Snapshot};
 
 /// A snapshot builder that can extract entities, resources, and [`Rollbacks`] from a [`World`].
 pub struct SnapshotBuilder<'a> {
@@ -38,7 +26,7 @@ impl<'a> SnapshotBuilder<'a> {
     /// # let mut app = App::new();
     /// # app.add_plugins(MinimalPlugins);
     /// # app.add_plugins(SavePlugins);
-    /// # let world = &mut app.world;
+    /// # let world = app.world_mut();
     /// SnapshotBuilder::snapshot(world)
     ///     // Extract all matching entities and resources
     ///     .extract_all()
@@ -73,7 +61,7 @@ impl<'a> SnapshotBuilder<'a> {
     /// # let mut app = App::new();
     /// # app.add_plugins(MinimalPlugins);
     /// # app.add_plugins(SavePlugins);
-    /// # let world = &mut app.world;
+    /// # let world = app.world_mut();
     /// SnapshotBuilder::rollback(world)
     ///     // Extract all matching entities and resources
     ///     .extract_all()

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,9 +1,6 @@
 use bevy::prelude::*;
 
-use crate::{
-    prelude::*,
-    Error,
-};
+use crate::{prelude::*, Error};
 
 /// Trait that defines how exactly your app saves and loads.
 pub trait Pipeline: Sized {
@@ -17,7 +14,7 @@ pub trait Pipeline: Sized {
 
     /// Called when the pipeline is initialized with [`App::init_pipeline`](`AppSaveableExt::init_pipeline`).
     fn build(app: &mut App) {
-        app.world.insert_resource(Self::Backend::default());
+        app.world_mut().insert_resource(Self::Backend::default());
     }
 
     /// Retrieve the unique identifier for the [`Snapshot`] being processed by the [`Pipeline`].

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,15 +1,6 @@
-use bevy::{
-    prelude::*,
-    scene::DynamicEntity,
-};
+use bevy::{prelude::*, scene::DynamicEntity};
 
-use crate::{
-    CloneReflect,
-    Error,
-    Rollbacks,
-    SnapshotApplier,
-    SnapshotBuilder,
-};
+use crate::{CloneReflect, Error, Rollbacks, SnapshotApplier, SnapshotBuilder};
 
 /// A collection of serializable entities and resources.
 ///
@@ -36,7 +27,7 @@ impl Snapshot {
     /// # let mut app = App::new();
     /// # app.add_plugins(MinimalPlugins);
     /// # app.add_plugins(SavePlugins);
-    /// # let world = &mut app.world;
+    /// # let world = app.world_mut();
     /// Snapshot::builder(world)
     ///     .extract_all_with_rollbacks()
     ///     .build();
@@ -53,7 +44,7 @@ impl Snapshot {
     /// # let mut app = App::new();
     /// # app.add_plugins(MinimalPlugins);
     /// # app.add_plugins(SavePlugins);
-    /// # let world = &mut app.world;
+    /// # let world = app.world_mut();
     /// Snapshot::builder(world)
     ///     // Extract all matching entities and resources
     ///     .extract_all()
@@ -87,7 +78,7 @@ impl Snapshot {
     /// # let mut app = App::new();
     /// # app.add_plugins(MinimalPlugins);
     /// # app.add_plugins(SavePlugins);
-    /// # let world = &mut app.world;
+    /// # let world = app.world_mut();
     /// # let parent = Entity::from_raw(0);
     /// let snapshot = Snapshot::from_world(world);
     ///

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -1,9 +1,6 @@
 use bevy::prelude::*;
 use bevy_save::prelude::*;
-use serde::{
-    de::DeserializeSeed,
-    Serialize,
-};
+use serde::{de::DeserializeSeed, Serialize};
 
 #[derive(Component, Reflect, Default)]
 #[reflect(Component)]
@@ -48,7 +45,7 @@ fn init_app() -> App {
         .register_type::<Option<u32>>()
         .register_type::<Position>();
 
-    let world = &mut app.world;
+    let world = app.world_mut();
 
     world.spawn(());
 
@@ -99,7 +96,7 @@ fn test_json() {
     }
 
     let mut app = init_app();
-    let world = &mut app.world;
+    let world = app.world_mut();
 
     let registry = world.resource::<AppTypeRegistry>();
     let snapshot = extract(world);
@@ -188,7 +185,7 @@ fn test_mp() {
     }
 
     let mut app = init_app();
-    let world = &mut app.world;
+    let world = app.world_mut();
 
     let registry = world.resource::<AppTypeRegistry>();
     let snapshot = extract(world);

--- a/tests/overwrite.rs
+++ b/tests/overwrite.rs
@@ -17,7 +17,7 @@ fn test_collect() {
     app.register_type::<Collect>();
     app.register_type::<Vec<u32>>();
 
-    let world = &mut app.world;
+    let world = app.world_mut();
 
     let entity = world
         .spawn_empty()
@@ -79,7 +79,7 @@ fn test_basic() {
 
     app.register_type::<Basic>();
 
-    let world = &mut app.world;
+    let world = app.world_mut();
 
     let entity = world.spawn_empty().insert(Basic { data: 0 }).id();
 


### PR DESCRIPTION
I haven't fixed a couple of tests because I'm unsure of why they are failing in the way they are. The test `test_json` expects that the entities get ids 0,1,2,3,4 but the ids seem to start from `u32::MAX + 1` for some reason. I also saw that when I ran the examples straight from master, the entity ids put into the json file were huge. This is despite the ids themselves starting from 0 before serialization. So I am unsure if this behavior is caused by the update of Bevy itself or something that differs in my environment.

Closes #37 