### PR TITLE
Fix MapEntities mapper avoid overwriting mappings

### DIFF
--- a/src/reflect/snapshot/applier.rs
+++ b/src/reflect/snapshot/applier.rs
@@ -222,7 +222,7 @@ impl Drop for MapEntitiesMapper<'_, '_> {
     fn drop(&mut self) {
         // WORKAROUND: We've already mapped, don't do it again.
         for mapped in self.map.values().copied().collect::<Vec<_>>() {
-            self.map.insert(mapped, mapped);
+            self.map.entry(mapped).or_insert(mapped);
         }
     }
 }


### PR DESCRIPTION
Issue I had is that at load entities got mixed up at load, the mapping i got when the world was empty, especially first entity points to a wrong relation:
```
2026-01-15T10:00:01.774780Z INFO main_game::save::systems: building 111v0 adds 127v0 as city 
2026-01-15T10:00:01.775096Z INFO main_game::save::systems: building 112v0 adds 118v0 as city 
2026-01-15T10:00:01.775317Z INFO main_game::save::systems: building 113v0 adds 117v0 as city 
2026-01-15T10:00:01.775519Z INFO main_game::save::systems: building 114v0 adds 117v0 as city 
2026-01-15T10:00:01.775710Z INFO main_game::save::systems: building 115v0 adds 116v0 as city 
2026-01-15T10:00:01.775926Z INFO main_game::save::systems: building 116v0 adds 116v0 as city 
2026-01-15T10:00:01.776162Z WARN bevy_ecs::relationship: src\save\systems.rs:193:14: The building_plugin::components::BuildingOf(116v0) relationship on entity 116v0 points to itself. The invalid building_plugin::components::BuildingOf relationship has been removed. 
2026-01-15T10:00:01.776349Z INFO main_game::save::systems: building 117v0 adds 116v0 as city 
2026-01-15T10:00:01.776473Z INFO main_game::save::systems: building 118v0 adds 116v0 as city 
2026-01-15T10:00:01.776595Z INFO main_game::save::systems: building 119v0 adds 115v0 as city 
...
2026-01-15T10:00:01.777267Z INFO main_game::save::systems: city "wardan" added as 118v0 
2026-01-15T10:00:01.777343Z INFO main_game::save::systems: city "al-khatatbah" added as 117v0 
2026-01-15T10:00:01.777424Z INFO main_game::save::systems: city "el-qassasin" added as 116v0 
2026-01-15T10:00:01.777485Z INFO main_game::save::systems: city "mahsama" added as 115v0 
2026-01-15T10:00:01.777547Z INFO main_game::save::systems: city "suez" added as 114v0 
2026-01-15T10:00:01.777617Z INFO main_game::save::systems: city "ismailia" added as 113v0
```
It was also only on the first load, second load of the save file it was fine.
ChatGPT explenation: MapEntities mapping sometimes becomes identity mid-load, breaking references; reproducible when loading snapshots where mapped targets can share IDs with snapshot sources.

The Drop workaround does map.insert(mapped, mapped) which can overwrite existing mappings.

I have tested this fix on top of the PR-68 (bevy 0.17), and it worked to load save files.