### PR TITLE
Flush smol::fs::File before dropping to prevent data loss.

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -151,7 +151,9 @@ mod desktop {
 
             let mut file = File::create(path).await?;
 
-            Ok(file.write_all(&buf).await?)
+            file.write_all(&buf).await?;
+
+            Ok(file.flush().await?)
         }
 
         async fn load<F: Format, S: for<'de> DeserializeSeed<'de, Value = T>, T>(
@@ -186,7 +188,9 @@ mod desktop {
 
             let mut file = File::create(format!("{key}{}", F::extension())).await?;
 
-            Ok(file.write_all(&buf).await?)
+            file.write_all(&buf).await?;
+
+            Ok(file.flush().await?)
         }
 
         async fn load<F: Format, S: for<'de> DeserializeSeed<'de, Value = T>, T>(


### PR DESCRIPTION
per https://docs.rs/smol/latest/smol/fs/struct.File.html, we need either flush(), sync_all(), or sync_data() before dropping the File. (I experienced a bug when saving data on Bevy app exit, by half the time finding 0-size files.)